### PR TITLE
feat: rerun flows by using inputs from another execution

### DIFF
--- a/site/src/lib/components/flow-input/FlowInputForm.svelte
+++ b/site/src/lib/components/flow-input/FlowInputForm.svelte
@@ -4,10 +4,29 @@
   import { ApiError } from '$lib/apiClient';
   import { handleInlineError } from '$lib/utils/errorHandling';
 
-  let { inputs, namespace, flowId }: { inputs: FlowInput[], namespace: string, flowId: string } = $props();
+  let {
+    inputs,
+    namespace,
+    flowId,
+    executionInput = null
+  }: {
+    inputs: FlowInput[],
+    namespace: string,
+    flowId: string,
+    executionInput?: Record<string, any> | null
+  } = $props();
 
   let loading = $state(false);
   let errors = $state<Record<string, string>>({});
+
+  const mergedInputs = $derived(
+    inputs.map(input => {
+      if (executionInput && executionInput[input.name] !== undefined) {
+        return { ...input, default: String(executionInput[input.name]) };
+      }
+      return input;
+    })
+  );
 
   const submit = async (event: SubmitEvent) => {
     event.preventDefault();
@@ -63,7 +82,7 @@
       </div>
     {/if}
 
-    {#each inputs as input (input.name)}
+    {#each mergedInputs as input (input.name)}
       <div>
         <label for={input.name} class="block text-sm font-medium text-gray-700 mb-2">
           {input.label || input.name}

--- a/site/src/routes/view/[namespace]/flows/[flowId]/+page.svelte
+++ b/site/src/routes/view/[namespace]/flows/[flowId]/+page.svelte
@@ -32,6 +32,8 @@
 
   let namespace = $derived(page.params.namespace);
   let flowId = $derived(page.params.flowId);
+  let rerunFromExecId = $derived(data.rerunFromExecId);
+  let showRerunBanner = $state(!!rerunFromExecId);
 
   // Check update permission on mount
   permissionChecker(data.user!, 'flow', data.namespaceId, ['update']).then(permissions => {
@@ -190,7 +192,44 @@
 <div class="px-6 py-8 bg-gray-50">
   {#if activeTab === 'run'}
     <div class="max-w-2xl mx-auto">
-      <FlowInputForm inputs={data.flowInputs || []} namespace={namespace!} flowId={flowId!} />
+      {#if showRerunBanner}
+        <div class="mb-6">
+          <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 flex items-start justify-between">
+            <div class="flex items-start gap-3">
+              <svg class="w-5 h-5 text-blue-600 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+              </svg>
+              <div class="flex-1">
+                <h3 class="text-sm font-medium text-blue-900">Rerunning execution</h3>
+                <p class="text-sm text-blue-700 mt-1">
+                  Inputs have been prepopulated from execution
+                  <a
+                    href="/view/{namespace}/results/{flowId}/{rerunFromExecId}"
+                    class="font-mono underline hover:text-blue-900"
+                  >
+                    {rerunFromExecId.substring(0, 8)}
+                  </a>
+                </p>
+              </div>
+            </div>
+            <button
+              onclick={() => showRerunBanner = false}
+              class="text-blue-400 hover:text-blue-600"
+              aria-label="Dismiss"
+            >
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+      {/if}
+      <FlowInputForm
+        inputs={data.flowInputs || []}
+        namespace={namespace!}
+        flowId={flowId!}
+        executionInput={data.executionInput}
+      />
       <div class="mt-6">
         <FlowSchedulesList schedules={data.flowMeta?.meta?.schedules || []} />
       </div>

--- a/site/src/routes/view/[namespace]/flows/[flowId]/+page.ts
+++ b/site/src/routes/view/[namespace]/flows/[flowId]/+page.ts
@@ -3,10 +3,9 @@ import type { PageLoad } from './$types';
 import { apiClient } from '$lib/apiClient';
 import { permissionChecker } from '$lib/utils/permissions';
 
-export const load: PageLoad = async ({ params, parent }) => {
+export const load: PageLoad = async ({ params, parent, url }) => {
   const { user, namespaceId } = await parent();
 
-  // Check permissions
   try {
     const permissions = await permissionChecker(user!, 'flow', namespaceId, ['view']);
     if (!permissions.canRead) {
@@ -17,7 +16,7 @@ export const load: PageLoad = async ({ params, parent }) => {
     }
   } catch (err) {
     if (err && typeof err === 'object' && 'status' in err) {
-      throw err; // Re-throw SvelteKit errors
+      throw err;
     }
     error(500, {
       message: 'Failed to check permissions',
@@ -25,15 +24,23 @@ export const load: PageLoad = async ({ params, parent }) => {
     });
   }
 
+  const rerunFromExecId = url.searchParams.get('rerun_from');
+
   try {
-    const [flowInputs, flowMeta] = await Promise.all([
+    const [flowInputs, flowMeta, executionData] = await Promise.all([
       apiClient.flows.getInputs(params.namespace, params.flowId),
-      apiClient.flows.getMeta(params.namespace, params.flowId)
+      apiClient.flows.getMeta(params.namespace, params.flowId),
+      rerunFromExecId
+        ? apiClient.executions.getById(params.namespace, rerunFromExecId).catch(() => null)
+        : Promise.resolve(null)
     ]);
-    
+
     return {
       flowInputs: flowInputs.inputs,
       flowMeta,
+      namespaceId,
+      rerunFromExecId,
+      executionInput: executionData?.input || null,
     };
   } catch (err) {
     error(500, 'Failed to load flow data');

--- a/site/src/routes/view/[namespace]/results/[flowId]/[logId]/+page.svelte
+++ b/site/src/routes/view/[namespace]/results/[flowId]/[logId]/+page.svelte
@@ -20,7 +20,7 @@
         showWarning,
     } from "$lib/utils/errorHandling";
     import { formatDateTime } from "$lib/utils";
-    import { IconPlayerStop } from "@tabler/icons-svelte";
+    import { IconPlayerStop, IconReload } from "@tabler/icons-svelte";
 
     let {
         data,
@@ -416,6 +416,10 @@
         }
     };
 
+    const handleRerun = () => {
+        goto(`/view/${namespace}/flows/${flowId}?rerun_from=${logId}`);
+    };
+
     // Initialize component
     onMount(() => {
         if (data.executionSummary) {
@@ -486,6 +490,12 @@
                           },
                       ]
                     : []),
+                {
+                    label: "Rerun",
+                    onClick: handleRerun,
+                    variant: "primary" as const,
+                    icon: IconReload,
+                },
             ]}
         >
             {#snippet children()}


### PR DESCRIPTION
This PR adds the re-run functionality as discussed in #9 

<img width="829" height="309" alt="Screenshot From 2025-12-07 11-41-36" src="https://github.com/user-attachments/assets/077d44c1-9b5d-4691-bf2d-e605d30266d3" />
<img width="963" height="654" alt="Screenshot From 2025-12-07 11-42-28" src="https://github.com/user-attachments/assets/fbfd863d-817e-4cf5-b680-6b4074d2d6ba" />
