### PR TITLE
feat: add file input support for flows

### DIFF
--- a/configs/config.sample.toml
+++ b/configs/config.sample.toml
@@ -25,6 +25,9 @@ root_url = "http://localhost:7000"
 # Valid key lengths are 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256
 secure_cookie_key = "{{ .App.SecureCookieKey }}"
 
+# (optional) Maximum file upload size in bytes (default: 104857600 = 100MB)
+# max_file_upload_size = 104857600
+
 [keystore]
 # (required) The keystore manages encryption keys for sensitive data
 # This is a random 32 byte key that is Base64 encoded

--- a/docs/docs/package-lock.json
+++ b/docs/docs/package-lock.json
@@ -2145,7 +2145,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2306,7 +2305,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.14.4.tgz",
       "integrity": "sha512-yqgMAO2Whi9GmZkByyiPcG7CiiPr0Me0iBSorMa6M0g+wQk/ewnIqUyr7T/uFCPTQndoKwucnYFTrf0yfb0urw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.12.2",
         "@astrojs/internal-helpers": "0.7.4",
@@ -2585,7 +2583,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
       "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -2787,7 +2784,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -3188,7 +3184,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6045,7 +6040,6 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
       "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.56.1"
       },
@@ -6120,7 +6114,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6651,7 +6644,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
       "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7416,7 +7408,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
       "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7664,7 +7655,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/docs/docs/src/content/docs/general/flows.mdx
+++ b/docs/docs/src/content/docs/general/flows.mdx
@@ -84,7 +84,7 @@ schedules:
     timezone: Asia/Kolkata
 ```
 
-<Aside>Only flows where all inputs have default values can be scheduled.</Aside>
+<Aside>Only flows where all inputs have default values can be scheduled. Flows with file inputs cannot be scheduled.</Aside>
 
 ## Inputs
 
@@ -164,7 +164,62 @@ inputs:
 ```
 
 </TabItem>
+
+<TabItem label="File">
+
+```yaml
+inputs:
+  - name: config_file
+    type: file
+    label: Configuration File
+    description: Upload a configuration file
+    required: true
+    max_file_size: 10485760  # Optional: 10MB limit (default: 100MB)
+```
+
+</TabItem>
 </Tabs>
+
+### File Inputs
+
+File inputs allow users to upload files when triggering a flow. The uploaded file is made available to actions via the artifacts system.
+
+#### Using File Inputs in Actions
+
+Reference file inputs using the standard `{{ inputs.file_name }}` syntax:
+
+```yaml
+inputs:
+  - name: data_file
+    type: file
+    label: Data File
+    required: true
+
+actions:
+  - id: process_file
+    name: Process Uploaded File
+    executor: docker
+    variables:
+      - file_path: "{{ inputs.data_file }}"
+    with:
+      image: docker.io/alpine
+      script: |
+        echo "Processing: $file_path"
+        cat "$file_path"
+        
+        # Files are also available in the uploads directory
+        ls -la $FC_ARTIFACTS/uploads/
+```
+
+#### File Input Limitations
+
+- **No default values**: File inputs cannot have default values
+- **Not schedulable**: Flows with file inputs cannot be scheduled (files must be provided at execution time)
+- **Size limits**: Default maximum file size is 100MB, configurable per-input via `max_file_size` (in bytes) or globally in server config
+
+#### Remote Execution
+
+When running on remote nodes, uploaded files are automatically transferred to the remote node before execution. The file path in your variable will point to the correct location on the remote system.
 
 ### Input Validation
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,15 +99,16 @@ type Logger struct {
 }
 
 type AppConfig struct {
-	AdminUsername   string `koanf:"admin_username"`
-	AdminPassword   string `koanf:"admin_password"`
-	RootURL         string `koanf:"root_url"`
-	Address         string `koanf:"address"`
-	UseTLS          bool   `koanf:"use_tls"`
-	HTTPTLSCert     string `koanf:"http_tls_cert"`
-	HTTPTLSKey      string `koanf:"http_tls_key"`
-	FlowsDirectory  string `koanf:"flows_directory"`
-	SecureCookieKey string `koanf:"secure_cookie_key"`
+	AdminUsername     string `koanf:"admin_username"`
+	AdminPassword     string `koanf:"admin_password"`
+	RootURL           string `koanf:"root_url"`
+	Address           string `koanf:"address"`
+	UseTLS            bool   `koanf:"use_tls"`
+	HTTPTLSCert       string `koanf:"http_tls_cert"`
+	HTTPTLSKey        string `koanf:"http_tls_key"`
+	FlowsDirectory    string `koanf:"flows_directory"`
+	SecureCookieKey   string `koanf:"secure_cookie_key"`
+	MaxFileUploadSize int64  `koanf:"max_file_upload_size"` // in bytes, default 100MB
 }
 
 type KeystoreConfig struct {
@@ -188,15 +189,16 @@ func GetDefaultConfig() Config {
 			SSLRootCert: "",
 		},
 		App: AppConfig{
-			AdminUsername:   "flowctl_admin",
-			AdminPassword:   "flowctl_password",
-			RootURL:         "http://localhost:7000",
-			Address:         ":7000",
-			UseTLS:          false,
-			HTTPTLSCert:     "server_cert.pem",
-			HTTPTLSKey:      "server_key.pem",
-			FlowsDirectory:  "flows",
-			SecureCookieKey: genKey(16),
+			AdminUsername:     "flowctl_admin",
+			AdminPassword:     "flowctl_password",
+			RootURL:           "http://localhost:7000",
+			Address:           ":7000",
+			UseTLS:            false,
+			HTTPTLSCert:       "server_cert.pem",
+			HTTPTLSKey:        "server_key.pem",
+			FlowsDirectory:    "flows",
+			SecureCookieKey:   genKey(16),
+			MaxFileUploadSize: 100 * 1024 * 1024, // 100MB
 		},
 		Keystore: KeystoreConfig{
 			KeeperURL: fmt.Sprintf("base64key://%s", genKey(32)),

--- a/internal/core/flows.go
+++ b/internal/core/flows.go
@@ -166,6 +166,12 @@ func (c *Core) GetFlowFromLogID(logID string, namespaceID string) (models.Flow, 
 // Exec ID should be universally unique, this is used to create the log stream and identify each execution
 // If scheduledAt is provided, the flow will be scheduled to run at that time instead of immediately.
 func (c *Core) QueueFlowExecution(ctx context.Context, f models.Flow, input map[string]interface{}, userUUID string, namespaceID string, scheduledAt *time.Time) (string, error) {
+	return c.QueueFlowExecutionWithExecID(ctx, f, input, userUUID, namespaceID, "", scheduledAt)
+}
+
+// QueueFlowExecutionWithExecID adds a flow in the execution queue with a pre-generated execution ID.
+// If execID is empty, a new UUID is generated. Use this when files need to be uploaded before queuing.
+func (c *Core) QueueFlowExecutionWithExecID(ctx context.Context, f models.Flow, input map[string]interface{}, userUUID string, namespaceID string, execID string, scheduledAt *time.Time) (string, error) {
 	if !f.Meta.AllowOverlap {
 		namespaceUUID, err := uuid.Parse(namespaceID)
 		if err != nil {
@@ -183,7 +189,7 @@ func (c *Core) QueueFlowExecution(ctx context.Context, f models.Flow, input map[
 		}
 	}
 
-	info, err := c.queueFlow(ctx, f, input, "", 0, userUUID, namespaceID, false, scheduledAt)
+	info, err := c.queueFlow(ctx, f, input, execID, 0, userUUID, namespaceID, false, scheduledAt)
 	if err != nil {
 		return "", err
 	}

--- a/internal/handlers/types.go
+++ b/internal/handlers/types.go
@@ -383,6 +383,7 @@ type FlowInput struct {
 	Type        string   `json:"type"`
 	Options     []string `json:"options"`
 	Default     string   `json:"default,omitempty"`
+	MaxFileSize int64    `json:"max_file_size,omitempty"`
 }
 
 type FlowInputsResp struct {
@@ -398,6 +399,7 @@ func coreFlowInputToInput(input models.Input) FlowInput {
 		Type:        string(input.Type),
 		Options:     input.Options,
 		Default:     input.Default,
+		MaxFileSize: input.MaxFileSize,
 	}
 }
 
@@ -672,6 +674,7 @@ type FlowInputReq struct {
 	Required    bool     `json:"required"`
 	Default     string   `json:"default"`
 	Options     []string `json:"options"`
+	MaxFileSize int64    `json:"max_file_size"`
 }
 
 type FlowActionReq struct {
@@ -722,6 +725,7 @@ func convertFlowInputsReqToInputs(inputsReq []FlowInputReq) []models.Input {
 			Required:    input.Required,
 			Default:     input.Default,
 			Options:     input.Options,
+			MaxFileSize: input.MaxFileSize,
 		}
 	}
 	return inputs
@@ -762,6 +766,7 @@ func convertFlowInputsToInputsReq(inputs []models.Input) []FlowInputReq {
 			Required:    input.Required,
 			Default:     input.Default,
 			Options:     input.Options,
+			MaxFileSize: input.MaxFileSize,
 		}
 	}
 	return inputsReq

--- a/internal/scheduler/types.go
+++ b/internal/scheduler/types.go
@@ -125,6 +125,7 @@ type Input struct {
 	Validation  string    `yaml:"validation" json:"validation"`
 	Required    bool      `yaml:"required" json:"required"`
 	Default     string    `yaml:"default" json:"default"`
+	MaxFileSize int64     `yaml:"max_file_size" json:"max_file_size"`
 }
 
 type Action struct {

--- a/site/src/lib/components/flow-create/FlowInputs.svelte
+++ b/site/src/lib/components/flow-create/FlowInputs.svelte
@@ -20,6 +20,13 @@
             input.options = [];
             input.optionsText = "";
         }
+        if (input.type === "file") {
+            input.default = "";
+        }
+        if (input.type !== "file") {
+            input.max_file_size = undefined;
+            input.maxFileSizeMB = undefined;
+        }
     }
 
     function updateOptions(input: any) {
@@ -96,7 +103,7 @@
                             <option value="number">Number</option>
                             <option value="checkbox">Checkbox</option>
                             <option value="password">Password</option>
-                            <!-- <option value="file">File</option> -->
+                            <option value="file">File</option>
                             <option value="datetime">DateTime</option>
                             <option value="select">Select</option>
                         </select>
@@ -127,14 +134,17 @@
                     </div>
                     <div>
                         <label
-                            class="block text-sm font-medium text-gray-700 mb-1"
+                            class="block text-sm font-medium mb-1"
+                            class:text-gray-700={input.type !== "file"}
+                            class:text-gray-400={input.type === "file"}
                             >Default Value</label
                         >
                         <input
                             type="text"
                             bind:value={input.default}
-                            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm"
-                            placeholder="Default value"
+                            disabled={input.type === "file"}
+                            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed"
+                            placeholder={input.type === "file" ? "Not available for file inputs" : "Default value"}
                         />
                     </div>
                     <div class="col-span-2">
@@ -161,7 +171,6 @@
                     </div>
                 </div>
 
-                <!-- Options for select type -->
                 {#if input.type === "select"}
                     <div class="mt-4 p-3 bg-gray-50 rounded-md">
                         <label
@@ -174,6 +183,24 @@
                             class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm font-mono h-20"
                             placeholder="option1&#10;option2&#10;option3"
                         ></textarea>
+                    </div>
+                {/if}
+
+                {#if input.type === "file"}
+                    <div class="mt-4 p-3 bg-gray-50 rounded-md">
+                        <label
+                            class="block text-sm font-medium text-gray-700 mb-2"
+                            >Max File Size (MB)</label
+                        >
+                        <input
+                            type="number"
+                            bind:value={input.maxFileSizeMB}
+                            oninput={() => input.max_file_size = (input.maxFileSizeMB || 0) * 1024 * 1024}
+                            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm"
+                            placeholder="Leave empty for default (100MB)"
+                            min="1"
+                        />
+                        <p class="text-xs text-gray-500 mt-1">Optional. Leave empty to use server default.</p>
                     </div>
                 {/if}
             </div>

--- a/site/src/lib/components/flow-create/FlowMetadata.svelte
+++ b/site/src/lib/components/flow-create/FlowMetadata.svelte
@@ -20,13 +20,15 @@
         updatemode?: boolean;
     } = $props();
 
-    // Compute schedulable status based on inputs
-    let isSchedulable = $derived(
-        inputs.length === 0 ||
-            inputs.every(
-                (input) => input.default && input.default.trim() !== "",
-            ),
+    let hasFileInputs = $derived(
+        inputs.some((input) => input.type === "file"),
     );
+
+    let hasMissingDefaults = $derived(
+        inputs.some((input) => input.type !== "file" && (!input.default || input.default.trim() === "")),
+    );
+
+    let isSchedulable = $derived(!hasFileInputs && !hasMissingDefaults);
 
     function updateName(value: string) {
         if (updatemode) return;
@@ -307,12 +309,21 @@
                                 Flow Not Schedulable
                             </h3>
                             <div class="mt-2 text-sm text-warning-700">
-                                <p>
-                                    This flow cannot be scheduled because it has
-                                    inputs without default values. To make this
-                                    flow schedulable, ensure all inputs have
-                                    default values.
-                                </p>
+                                {#if hasFileInputs}
+                                    <p>
+                                        This flow cannot be scheduled because it has
+                                        file inputs. Flows with file inputs cannot
+                                        be scheduled as files must be provided at
+                                        execution time.
+                                    </p>
+                                {:else}
+                                    <p>
+                                        This flow cannot be scheduled because it has
+                                        inputs without default values. To make this
+                                        flow schedulable, ensure all inputs have
+                                        default values.
+                                    </p>
+                                {/if}
                             </div>
                         </div>
                     </div>

--- a/site/src/lib/components/flow-input/FlowInputForm.svelte
+++ b/site/src/lib/components/flow-input/FlowInputForm.svelte
@@ -163,16 +163,21 @@
               <option value={option} selected={option === input.default}>{option}</option>
             {/each}
           </select>
-          <!-- {:else if input.type === 'file'}
-          <div class="flex items-center">
+          {:else if input.type === 'file'}
+          <div class="flex flex-col">
             <input
               type="file"
               id={input.name}
               name={input.name}
               required={input.required}
-              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-primary-50 file:text-primary-700 hover:file:bg-primary-100"
+              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-primary-50 file:text-primary-700 hover:file:bg-primary-100"
             />
-          </div> -->
+            {#if input.max_file_size}
+              <p class="text-xs text-gray-500 mt-1">
+                Max size: {Math.round(input.max_file_size / (1024 * 1024))}MB
+              </p>
+            {/if}
+          </div>
           {:else if input.type === 'datetime'}
           <div class="flex items-center">
             <input

--- a/site/src/lib/types.ts
+++ b/site/src/lib/types.ts
@@ -83,6 +83,7 @@ export interface FlowInput {
     | "select";
   options: string[];
   default?: string;
+  max_file_size?: number;
 }
 
 export interface FlowInputsResp {
@@ -444,6 +445,7 @@ export interface FlowInputReq {
   required?: boolean;
   default?: string;
   options?: string[];
+  max_file_size?: number;
 }
 
 export interface FlowActionReq {


### PR DESCRIPTION
## Summary

Adds file input support for flows, allowing users to upload files when triggering flows. Uploaded files are made available to flow actions via the artifacts system, with full support for remote node execution.

## Changes

### Backend

- **Config**: Added `max_file_upload_size` global config option (default 100MB)
- **Models**: Added `MaxFileSize` field to `Input` struct for per-input size limits
- **Validation**: File inputs cannot have default values; flows with file inputs cannot be scheduled
- **File Upload**: Files saved to artifacts directory (`/tmp/artifacts-store-{execID}/uploads/`)
- **Remote Execution**: Added path transformation so file paths resolve correctly on remote nodes
- **Core API**: Added `QueueFlowExecutionWithExecID` to support pre-generated execution IDs (needed for file upload path resolution)

### Frontend

- Enabled "File" option in input type dropdown
- Added max file size configuration field for file inputs
- Disabled default value field when file type is selected
- Added file input rendering in flow execution form with size hint
- Updated scheduling warning to show appropriate message for file inputs vs missing defaults

### Documentation

- Added File input type documentation with examples
- Documented file input limitations (no defaults, not schedulable, size limits)
- Added usage examples for accessing files in actions

## Usage

```yaml
inputs:
  - name: config_file
    type: file
    label: Configuration File
    required: true
    max_file_size: 10485760  # Optional: 10MB limit

actions:
  - id: process
    name: Process File
    executor: docker
    variables:
      - file_path: "{{ inputs.config_file }}"
    with:
      image: alpine
      script: |
        cat "$file_path"
        # Or access via: $FC_ARTIFACTS/uploads/
```

## Testing

- [x] File upload with valid file succeeds
- [x] File available in action via `{{ inputs.file_name }}`
- [x] Remote execution: files transferred correctly
- [x] Flow with file inputs shows correct "not schedulable" message
- [x] Default value field disabled for file inputs

## Screenshots

<img width="1387" height="491" alt="Screenshot 2025-12-30 at 19-35-56 Run Flow - File test flow" src="https://github.com/user-attachments/assets/4b22384b-eeff-415c-844e-333d6a18316b" />
<img width="1152" height="675" alt="Screenshot 2025-12-30 at 19-36-51 Edit Flow - File test flow Flowctl" src="https://github.com/user-attachments/assets/cf12d3c2-67c3-4bc9-a845-abd58f1a9769" />
<img width="1152" height="665" alt="Screenshot 2025-12-30 at 19-37-10 Edit Flow - File test flow Flowctl" src="https://github.com/user-attachments/assets/4869d15a-bad7-4d2a-9049-d3142516ad9c" />
<img width="1031" height="1041" alt="Screenshot 2025-12-30 at 19-37-59 Edit Flow - File test flow Flowctl" src="https://github.com/user-attachments/assets/d13f0b63-1abb-4374-b36a-6313847ab28d" />

