### PR TITLE
fix: replace panic with error return in messenger schema registration

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -102,8 +102,11 @@ func initMessengers(cfg config.MessengersConfig, groupResolver messengers.GroupR
 			logger.Error("failed to create email messenger", "error", err)
 		} else {
 			m["email"] = emailMessenger
-			messengers.RegisterSchema("email", messengers.GetEmailNotifySchema())
-			logger.Info("email messenger initialized")
+			if err := messengers.RegisterSchema("email", messengers.GetEmailNotifySchema()); err != nil {
+				logger.Error("failed to register messenger schema", "error", err)
+			} else {
+				logger.Info("email messenger initialized")
+			}
 		}
 	}
 
@@ -113,8 +116,11 @@ func initMessengers(cfg config.MessengersConfig, groupResolver messengers.GroupR
 			logger.Error("failed to create webhook messenger", "error", err)
 		} else {
 			m["webhook"] = webhookMessenger
-			messengers.RegisterSchema("webhook", messengers.GetWebhookNotifySchema())
-			logger.Info("webhook messenger initialized")
+			if err := messengers.RegisterSchema("webhook", messengers.GetWebhookNotifySchema()); err != nil {
+				logger.Error("failed to register messenger schema", "error", err)
+			} else {
+				logger.Info("webhook messenger initialized")
+			}
 		}
 	}
 

--- a/internal/messengers/registry.go
+++ b/internal/messengers/registry.go
@@ -10,15 +10,16 @@ var (
 	smu            sync.RWMutex
 )
 
-// RegisterSchema registers a messenger's config schema. Panics on duplicate.
-func RegisterSchema(name string, schema any) {
+// RegisterSchema registers a messenger's config schema. Returns an error on duplicate.
+func RegisterSchema(name string, schema any) error {
 	smu.Lock()
 	defer smu.Unlock()
 
 	if _, exists := schemaRegistry[name]; exists {
-		panic(fmt.Sprintf("messenger schema '%s' is already registered", name))
+		return fmt.Errorf("messenger schema '%s' is already registered", name)
 	}
 	schemaRegistry[name] = schema
+	return nil
 }
 
 // GetAllSchemas returns a map of all registered messenger names to their config schemas.


### PR DESCRIPTION
## Summary

- Change `RegisterSchema()` in `internal/messengers/registry.go` to return `error` instead of panicking on duplicate registration
- Update both callers in `cmd/start.go` (`initMessengers()`) to handle the error gracefully by logging and continuing
- Follows the existing error handling pattern used by `NewEmailMessenger` and `NewWebhookMessenger` in the same function

## Test plan

- [ ] Verify application starts normally with email and webhook messengers enabled
- [ ] Verify duplicate schema registration logs an error instead of crashing
- [ ] Verify messengers function correctly after startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)