### PR TITLE
feat: add flow duplication endpoint for quick cloning

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -343,6 +343,7 @@ func startServer(db *sqlx.DB, co *core.Core, metricsManager *metrics.Manager, lo
 	namespaceGroup.GET("/flows", h.HandleFlowsPagination, h.AuthorizeNamespaceAction(models.ResourceFlow, models.RBACActionView))
 	namespaceGroup.POST("/flows", h.HandleCreateFlow, h.AuthorizeNamespaceAction(models.ResourceFlow, models.RBACActionCreate))
 	namespaceGroup.GET("/flows/:flowID", h.HandleGetFlow, h.AuthorizeNamespaceAction(models.ResourceFlow, models.RBACActionView))
+	namespaceGroup.POST("/flows/:flowID/duplicate", h.HandleDuplicateFlow, h.AuthorizeNamespaceAction(models.ResourceFlow, models.RBACActionCreate))
 	namespaceGroup.PUT("/flows/:flowID", h.HandleUpdateFlow, h.AuthorizeNamespaceAction(models.ResourceFlow, models.RBACActionUpdate))
 	namespaceGroup.DELETE("/flows/:flowID", h.HandleDeleteFlow, h.AuthorizeNamespaceAction(models.ResourceFlow, models.RBACActionDelete))
 	namespaceGroup.GET("/flows/executions/:execID", h.HandleGetExecutionSummary, h.AuthorizeNamespaceAction(models.ResourceFlow, models.RBACActionView))

--- a/internal/handlers/flows.go
+++ b/internal/handlers/flows.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cvhariharan/flowctl/internal/core/models"
@@ -610,6 +611,56 @@ func (h *Handler) HandleCreateFlow(c echo.Context) error {
 	return c.JSON(http.StatusCreated, FlowCreateResp{
 		ID: flow.Meta.ID,
 	})
+}
+
+func (h *Handler) HandleDuplicateFlow(c echo.Context) error {
+	namespaceID, ok := c.Get("namespace").(string)
+	if !ok {
+		return wrapError(ErrRequiredFieldMissing, "could not get namespace", nil, nil)
+	}
+
+	sourceFlowID := c.Param("flowID")
+	if sourceFlowID == "" {
+		return wrapError(ErrRequiredFieldMissing, "flow ID cannot be empty", nil, nil)
+	}
+
+	var req FlowDuplicateReq
+	if err := c.Bind(&req); err != nil && err != io.EOF {
+		return wrapError(ErrInvalidInput, "invalid request", err, nil)
+	}
+	if err := h.validate.Struct(req); err != nil {
+		return wrapError(ErrValidationFailed, fmt.Sprintf("request validation failed: %s", formatValidationErrors(err)), err, nil)
+	}
+
+	sourceFlow, err := h.co.GetFlowByID(sourceFlowID, namespaceID)
+	if err != nil {
+		return wrapError(ErrResourceNotFound, "flow not found", err, nil)
+	}
+
+	name := req.Name
+	if strings.TrimSpace(name) == "" {
+		name = sourceFlow.Meta.Name + " Copy"
+	}
+
+	candidateID := GenerateSlug(name)
+	finalID := candidateID
+	for i := 2; i <= 100; i++ {
+		if _, err := h.co.GetFlowByID(finalID, namespaceID); err != nil {
+			break
+		}
+		finalID = fmt.Sprintf("%s_%d", candidateID, i)
+	}
+
+	dupFlow := sourceFlow
+	dupFlow.Meta.DBID = 0
+	dupFlow.Meta.ID = finalID
+	dupFlow.Meta.Name = name
+
+	if err := h.co.CreateFlow(c.Request().Context(), dupFlow, namespaceID); err != nil {
+		return wrapError(ErrOperationFailed, err.Error(), err, nil)
+	}
+
+	return c.JSON(http.StatusCreated, FlowCreateResp{ID: dupFlow.Meta.ID})
 }
 
 func (h *Handler) HandleUpdateFlow(c echo.Context) error {

--- a/internal/handlers/types.go
+++ b/internal/handlers/types.go
@@ -696,6 +696,10 @@ type FlowGetReq struct {
 	FlowID string `param:"flowID" validate:"required"`
 }
 
+type FlowDuplicateReq struct {
+	Name string `json:"name" validate:"omitempty,max=150,alphanum_whitespace"`
+}
+
 type LogStreamingReq struct {
 	LogID string `param:"logID" validate:"required,uuid4"`
 }


### PR DESCRIPTION
## Summary
Implements flow duplication support by adding a dedicated endpoint that clones an existing flow into a new flow file and refreshes in-memory/db state via the existing create flow path.

## Linked issue
Closes #18

## What changed
- Added `POST /:namespace/flows/:flowID/duplicate`
- Added `FlowDuplicateReq` with optional `name`
- Duplication handler behavior:
  - loads source flow by ID
  - derives a new ID from requested (or default) name
  - auto-resolves ID collisions with suffixes (`_2`, `_3`, ...)
  - creates a new flow via `CreateFlow` (which writes file + imports/refreshes)
- Registered route in `cmd/start.go`

## Notes
- If `name` is omitted, default name is `<source name> Copy`
- New flow ID is slugified and collision-safe

## Validation
- Static validation by code inspection and route wiring
- (Local Go test run skipped in this environment because `go` binary is not installed)
