### PR TITLE
fix: hide inactive schedules from upcoming scheduled runs

### DIFF
--- a/site/src/lib/components/flows/ScheduledExecutionsList.svelte
+++ b/site/src/lib/components/flows/ScheduledExecutionsList.svelte
@@ -27,8 +27,8 @@
   let upcomingRuns = $derived.by(() => {
     const runs: UpcomingRun[] = [];
 
-    // Add cron-based runs
-    for (const cron of cronSchedules) {
+    // Add cron-based runs (only active schedules)
+    for (const cron of cronSchedules.filter(c => c.is_active)) {
       const nextRun = getNextCronRun(cron.cron, cron.timezone);
       if (nextRun) {
         runs.push({


### PR DESCRIPTION
## Related Issue

Fixes #91

## Description

When a cron schedule is deactivated, the "Upcoming Scheduled Runs" section still shows the next occurrence, giving the impression the flow will execute. This PR filters out inactive schedules from the list.

## Checklist

- [x] Issue was assigned to me before submitting this PR
- [x] Documentation is updated (if applicable)
