### PR TITLE
Fix/smtp skip auth empty credentials

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,16 +162,15 @@ type WebhookConfig struct {
 }
 
 type SMTPConfig struct {
-	Enabled        bool   `koanf:"enabled"`
-	Host           string `koanf:"host" validate:"required_if=Enabled true"`
-	Port           int    `koanf:"port" validate:"required_if=Enabled true,min=1,max=65535"`
-	Username       string `koanf:"username"`
-	Password       string `koanf:"password"`
-	FromAddress    string `koanf:"from_address" validate:"required_if=Enabled true,email"`
-	FromName       string `koanf:"from_name"`
-	MaxConns       int    `koanf:"max_conns" validate:"min=1"`
-	SSL            string `koanf:"ssl" validate:"omitempty,oneof=none tls starttls"`
-	TLSSkipVerify  bool   `koanf:"tls_skip_verify"`
+	Enabled     bool   `koanf:"enabled"`
+	Host        string `koanf:"host" validate:"required_if=Enabled true"`
+	Port        int    `koanf:"port" validate:"required_if=Enabled true,min=1,max=65535"`
+	Username    string `koanf:"username"`
+	Password    string `koanf:"password"`
+	FromAddress string `koanf:"from_address" validate:"required_if=Enabled true,email"`
+	FromName    string `koanf:"from_name"`
+	MaxConns    int    `koanf:"max_conns" validate:"min=1"`
+	SSL         string `koanf:"ssl" validate:"omitempty,oneof=none tls starttls"`
 }
 
 func Load(configPath string) (Config, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,15 +162,16 @@ type WebhookConfig struct {
 }
 
 type SMTPConfig struct {
-	Enabled     bool   `koanf:"enabled"`
-	Host        string `koanf:"host" validate:"required_if=Enabled true"`
-	Port        int    `koanf:"port" validate:"required_if=Enabled true,min=1,max=65535"`
-	Username    string `koanf:"username"`
-	Password    string `koanf:"password"`
-	FromAddress string `koanf:"from_address" validate:"required_if=Enabled true,email"`
-	FromName    string `koanf:"from_name"`
-	MaxConns    int    `koanf:"max_conns" validate:"min=1"`
-	SSL         string `koanf:"ssl" validate:"omitempty,oneof=none tls starttls"`
+	Enabled        bool   `koanf:"enabled"`
+	Host           string `koanf:"host" validate:"required_if=Enabled true"`
+	Port           int    `koanf:"port" validate:"required_if=Enabled true,min=1,max=65535"`
+	Username       string `koanf:"username"`
+	Password       string `koanf:"password"`
+	FromAddress    string `koanf:"from_address" validate:"required_if=Enabled true,email"`
+	FromName       string `koanf:"from_name"`
+	MaxConns       int    `koanf:"max_conns" validate:"min=1"`
+	SSL            string `koanf:"ssl" validate:"omitempty,oneof=none tls starttls"`
+	TLSSkipVerify  bool   `koanf:"tls_skip_verify"`
 }
 
 func Load(configPath string) (Config, error) {

--- a/internal/messengers/email.go
+++ b/internal/messengers/email.go
@@ -3,7 +3,6 @@ package messengers
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"embed"
 	"fmt"
 	"html/template"
@@ -60,7 +59,6 @@ func NewEmailMessenger(cfg config.SMTPConfig, groupResolver GroupResolver, logge
 		MaxConns: cfg.MaxConns,
 		Auth:     smtpAuth(cfg.Username, cfg.Password),
 		SSL:      sslType,
-		TLSConfig: smtpTLSConfig(cfg.Host, cfg.TLSSkipVerify),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SMTP pool: %w", err)
@@ -232,18 +230,6 @@ func smtpAuth(username, password string) smtp.Auth {
 		return nil
 	}
 	return &smtppool.LoginAuth{Username: username, Password: password}
-}
-
-// smtpTLSConfig returns a TLS config with the given server name.
-// If skipVerify is true, certificate verification is disabled.
-func smtpTLSConfig(host string, skipVerify bool) *tls.Config {
-	if !skipVerify && host != "" {
-		return &tls.Config{ServerName: host}
-	}
-	if skipVerify {
-		return &tls.Config{InsecureSkipVerify: true}
-	}
-	return nil
 }
 
 // Close closes the SMTP connection pool

--- a/internal/messengers/email.go
+++ b/internal/messengers/email.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"html/template"
 	"log/slog"
+	"net/smtp"
 	"strings"
 
 	"github.com/cvhariharan/flowctl/internal/config"
@@ -226,7 +227,7 @@ func (e *EmailMessenger) resolveReceivers(ctx context.Context, receivers []strin
 
 // smtpAuth returns nil when username is empty, skipping SMTP AUTH entirely.
 // This allows connecting to local MTAs that don't require authentication.
-func smtpAuth(username, password string) *smtppool.LoginAuth {
+func smtpAuth(username, password string) smtp.Auth {
 	if username == "" {
 		return nil
 	}

--- a/internal/messengers/email.go
+++ b/internal/messengers/email.go
@@ -3,6 +3,7 @@ package messengers
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"embed"
 	"fmt"
 	"html/template"
@@ -56,8 +57,9 @@ func NewEmailMessenger(cfg config.SMTPConfig, groupResolver GroupResolver, logge
 		Host:     cfg.Host,
 		Port:     cfg.Port,
 		MaxConns: cfg.MaxConns,
-		Auth:     &smtppool.LoginAuth{Username: cfg.Username, Password: cfg.Password},
+		Auth:     smtpAuth(cfg.Username, cfg.Password),
 		SSL:      sslType,
+		TLSConfig: smtpTLSConfig(cfg.Host, cfg.TLSSkipVerify),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SMTP pool: %w", err)
@@ -220,6 +222,27 @@ func (e *EmailMessenger) resolveReceivers(ctx context.Context, receivers []strin
 		}
 	}
 	return to
+}
+
+// smtpAuth returns nil when username is empty, skipping SMTP AUTH entirely.
+// This allows connecting to local MTAs that don't require authentication.
+func smtpAuth(username, password string) *smtppool.LoginAuth {
+	if username == "" {
+		return nil
+	}
+	return &smtppool.LoginAuth{Username: username, Password: password}
+}
+
+// smtpTLSConfig returns a TLS config with the given server name.
+// If skipVerify is true, certificate verification is disabled.
+func smtpTLSConfig(host string, skipVerify bool) *tls.Config {
+	if !skipVerify && host != "" {
+		return &tls.Config{ServerName: host}
+	}
+	if skipVerify {
+		return &tls.Config{InsecureSkipVerify: true}
+	}
+	return nil
 }
 
 // Close closes the SMTP connection pool


### PR DESCRIPTION
Fixes #97 

file impacted, only `internal/messengers/email.go`